### PR TITLE
Mcho/dev

### DIFF
--- a/ps_banner.php
+++ b/ps_banner.php
@@ -64,7 +64,8 @@ class Ps_Banner extends Module implements WidgetInterface
             $this->registerHook('actionObjectLanguageAddAfter') &&
             $this->installFixtures() &&
             $this->uninstallPrestaShop16Module() &&
-            $this->disableDevice(Context::DEVICE_MOBILE));
+            $this->disableDevice(Context::DEVICE_MOBILE)) &&
+            $this->updatePosition(Hook::getIdByName('displayHome'), false, 3);
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | on reset or uninstall then install, modules are hooked in the wrong place
| Type?         | bug fix
| BC breaks?    | yes
| Deprecations? | yes
| Fixed ticket? | Fixes PrestaShop/Prestashop#20748
| How to test?  | Steps to reproduce the behavior:

Go to BO > Module Manager page > Search for the slider module
Click on reset
Go to FO > Home page
See error => the banner is at the last position on the home page

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
