### PR TITLE
Fetch banner image size

### DIFF
--- a/ps_banner.php
+++ b/ps_banner.php
@@ -272,7 +272,8 @@ class Ps_Banner extends Module implements WidgetInterface
 
             $this->smarty->assign([
                 'banner_img' => $this->context->link->protocol_content . Tools::getMediaServer($imgname) . $this->_path . 'img/' . $imgname,
-                'banner_sizes' => $sizes
+                'banner_width' => $sizes[0],
+                'banner_height' => $sizes[1]
             ]);
         }
 

--- a/ps_banner.php
+++ b/ps_banner.php
@@ -265,9 +265,15 @@ class Ps_Banner extends Module implements WidgetInterface
     public function getWidgetVariables($hookName, array $params)
     {
         $imgname = Configuration::get('BANNER_IMG', $this->context->language->id);
+        $imgDir = _PS_MODULE_DIR_ . $this->name . DIRECTORY_SEPARATOR . 'img' . DIRECTORY_SEPARATOR . $imgname;
 
-        if ($imgname && file_exists(_PS_MODULE_DIR_.$this->name.DIRECTORY_SEPARATOR.'img'.DIRECTORY_SEPARATOR.$imgname)) {
-            $this->smarty->assign('banner_img', $this->context->link->protocol_content . Tools::getMediaServer($imgname) . $this->_path . 'img/' . $imgname);
+        if ($imgname && file_exists($imgDir)) {
+            $sizes = getimagesize($imgDir);
+
+            $this->smarty->assign([
+                'banner_img' => $this->context->link->protocol_content . Tools::getMediaServer($imgname) . $this->_path . 'img/' . $imgname,
+                'banner_sizes' => $sizes
+            ]);
         }
 
         $banner_link = Configuration::get('BANNER_LINK', $this->context->language->id);

--- a/ps_banner.tpl
+++ b/ps_banner.tpl
@@ -24,7 +24,12 @@
  *}
 <a class="banner" href="{$banner_link}">
   {if isset($banner_img)}
-    <img src="{$banner_img}" alt="{$banner_desc}" title="{$banner_desc}">
+    <img
+      class="img-fluid"
+      src="{$banner_img}"
+      alt="{$banner_desc}"
+      title="{$banner_desc}"
+      {if isset($banner_sizes[3])}{$banner_sizes[3] nofilter}{/if}>
   {else}
     <span>{$banner_desc}</span>
   {/if}

--- a/ps_banner.tpl
+++ b/ps_banner.tpl
@@ -29,7 +29,8 @@
       src="{$banner_img}"
       alt="{$banner_desc}"
       title="{$banner_desc}"
-      {if isset($banner_sizes[3])}{$banner_sizes[3] nofilter}{/if}>
+      width="{$banner_width}"
+      height="{$banner_height}"
   {else}
     <span>{$banner_desc}</span>
   {/if}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | We should set width and height for image to reduce CLS, also it is good practice to set width and height on images to keep them in proper ratio util they are downloaded by browser. 
| Type?         | improvement
| BC breaks?    |  no
| Deprecations? |  no
| Fixed ticket? | Fixes PrestaShop/Prestashop#25852.
| How to test?  | It will require to remove file from theme that overrides module file `themes/classic/modules/ps_banner/ps_banner.tpl`. Then follow steps in issue. 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
