### PR TITLE
Fix banner configuration input

### DIFF
--- a/views/templates/admin/_configure/helpers/form/form.tpl
+++ b/views/templates/admin/_configure/helpers/form/form.tpl
@@ -26,7 +26,7 @@
 {extends file="helpers/form/form.tpl"}
 {block name="field"}
 	{if $input.type == 'file_lang'}
-		<div class="col-lg-9">
+		<div class="col-lg-8">
 			{foreach from=$languages item=language}
 				{if $languages|count > 1}
 					<div class="translatable-field lang-{$language.id_lang}" {if $language.id_lang != $defaultFormLanguage}style="display:none"{/if}>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Banner module is extending legacy form with custom input, however with a wrong class now.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#25911
| How to test?  | Open banner module config before and after the change.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
