### PR TITLE
Use getConfigInMultipleLangs() instead of getInt() as it's deprecated

### DIFF
--- a/ps_banner.php
+++ b/ps_banner.php
@@ -77,10 +77,10 @@ class Ps_Banner extends Module implements WidgetInterface
         }
 
         // Data migration
-        Configuration::updateValue('BANNER_IMG',Configuration::getInt('BLOCKBANNER_IMG'));
-        Configuration::updateValue('BANNER_LINK', Configuration::getInt('BLOCKBANNER_LINK'));
-        Configuration::updateValue('BANNER_DESC', Configuration::getInt('BLOCKBANNER_DESC'));
-        
+        Configuration::updateValue('BANNER_IMG',Configuration::getConfigInMultipleLangs('BLOCKBANNER_IMG'));
+        Configuration::updateValue('BANNER_LINK', Configuration::getConfigInMultipleLangs('BLOCKBANNER_LINK'));
+        Configuration::updateValue('BANNER_DESC', Configuration::getConfigInMultipleLangs('BLOCKBANNER_DESC'));
+
         $oldModule = Module::getInstanceByName(self::PS_16_EQUIVALENT_MODULE);
         if ($oldModule) {
             $oldModule->uninstall();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | As the getInt() method of Configuration is deprecated and could be removed into next major version of PrestaShop, we update this method. (Cfr. https://github.com/PrestaShop/PrestaShop/pull/26306)
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Nothing really to test.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
