### PR TITLE
Using the getConfigInMultipleLangs method instead of getInt (Deprecated)

### DIFF
--- a/ps_banner.php
+++ b/ps_banner.php
@@ -76,10 +76,20 @@ class Ps_Banner extends Module implements WidgetInterface
             return true;
         }
 
+        if (version_compare(_PS_VERSION_, '8.0.0', '>=')) {
+            $blockBannerImgValue = Configuration::getConfigInMultipleLangs('BLOCKBANNER_IMG');
+            $blockBannerLinkValue = Configuration::getConfigInMultipleLangs('BLOCKBANNER_LINK');
+            $blockBannerDescValue = Configuration::getConfigInMultipleLangs('BLOCKBANNER_DESC');
+        } else {
+            $blockBannerImgValue = Configuration::getInt('BLOCKBANNER_IMG');
+            $blockBannerLinkValue = Configuration::getInt('BLOCKBANNER_LINK');
+            $blockBannerDescValue = Configuration::getInt('BLOCKBANNER_DESC');
+        }
+
         // Data migration
-        Configuration::updateValue('BANNER_IMG', Configuration::getInt('BLOCKBANNER_IMG'));
-        Configuration::updateValue('BANNER_LINK', Configuration::getInt('BLOCKBANNER_LINK'));
-        Configuration::updateValue('BANNER_DESC', Configuration::getInt('BLOCKBANNER_DESC'));
+        Configuration::updateValue('BANNER_IMG', $blockBannerImgValue);
+        Configuration::updateValue('BANNER_LINK', $blockBannerLinkValue);
+        Configuration::updateValue('BANNER_DESC', $blockBannerDescValue);
 
         $oldModule = Module::getInstanceByName(self::PS_16_EQUIVALENT_MODULE);
         if ($oldModule) {

--- a/tests/phpstan/phpstan-1.7.1.2.neon
+++ b/tests/phpstan/phpstan-1.7.1.2.neon
@@ -4,3 +4,4 @@ includes:
 parameters:
   ignoreErrors:
     - '#Call to method assign\(\) on an unknown class Smarty_Data.#'
+    - '#Call to an undefined static method Configuration::getConfigInMultipleLangs\(\).#'

--- a/tests/phpstan/phpstan-1.7.2.5.neon
+++ b/tests/phpstan/phpstan-1.7.2.5.neon
@@ -4,3 +4,4 @@ includes:
 parameters:
   ignoreErrors:
     - '#Call to method assign\(\) on an unknown class Smarty_Data.#'
+    - '#Call to an undefined static method Configuration::getConfigInMultipleLangs\(\).#'

--- a/tests/phpstan/phpstan-1.7.3.4.neon
+++ b/tests/phpstan/phpstan-1.7.3.4.neon
@@ -4,3 +4,4 @@ includes:
 parameters:
   ignoreErrors:
     - '#Call to method assign\(\) on an unknown class Smarty_Data.#'
+    - '#Call to an undefined static method Configuration::getConfigInMultipleLangs\(\).#'

--- a/tests/phpstan/phpstan-1.7.4.4.neon
+++ b/tests/phpstan/phpstan-1.7.4.4.neon
@@ -3,3 +3,4 @@ includes:
 
 parameters:
   ignoreErrors:
+    - '#Call to an undefined static method Configuration::getConfigInMultipleLangs\(\).#'

--- a/tests/phpstan/phpstan-1.7.5.1.neon
+++ b/tests/phpstan/phpstan-1.7.5.1.neon
@@ -3,3 +3,4 @@ includes:
 
 parameters:
   ignoreErrors:
+    - '#Call to an undefined static method Configuration::getConfigInMultipleLangs\(\).#'

--- a/tests/phpstan/phpstan-1.7.6.neon
+++ b/tests/phpstan/phpstan-1.7.6.neon
@@ -3,3 +3,4 @@ includes:
 
 parameters:
   ignoreErrors:
+    - '#Call to an undefined static method Configuration::getConfigInMultipleLangs\(\).#'

--- a/tests/phpstan/phpstan-1.7.7.neon
+++ b/tests/phpstan/phpstan-1.7.7.neon
@@ -3,3 +3,4 @@ includes:
 
 parameters:
   ignoreErrors:
+    - '#Call to an undefined static method Configuration::getConfigInMultipleLangs\(\).#'

--- a/tests/phpstan/phpstan-1.7.8.neon
+++ b/tests/phpstan/phpstan-1.7.8.neon
@@ -3,3 +3,4 @@ includes:
 
 parameters:
   ignoreErrors:
+    - '#Call to an undefined static method Configuration::getConfigInMultipleLangs\(\).#'

--- a/tests/phpstan/phpstan-latest.neon
+++ b/tests/phpstan/phpstan-latest.neon
@@ -3,3 +3,4 @@ includes:
 
 parameters:
   ignoreErrors:
+    - '#Call to an undefined static method Configuration::getInt\(\).#'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Using the getConfigInMultipleLangs method instead of getInt (Deprecated) for fixing the CI. See https://github.com/PrestaShop/ps_banner/pull/54#issuecomment-1572071201
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | CI is green
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
