### PR TITLE
ps_banner module forces the 'http://' prefix to its link

### DIFF
--- a/ps_banner.php
+++ b/ps_banner.php
@@ -294,17 +294,8 @@ class Ps_Banner extends Module implements WidgetInterface
         }
 
         return [
-            'banner_link' => $this->updateUrl($banner_link),
+            'banner_link' => $banner_link,
             'banner_desc' => Configuration::get('BANNER_DESC', $this->context->language->id),
         ];
-    }
-
-    private function updateUrl($link)
-    {
-        if (substr($link, 0, 7) !== 'http://' && substr($link, 0, 8) !== 'https://') {
-            $link = 'http://' . $link;
-        }
-
-        return $link;
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | We shouldn't force any protocol. We should leave url "as is".
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/39524
| How to test?  | Add link without http:// and without https://, then check, if there is link as user write exactly.
